### PR TITLE
extern"C"

### DIFF
--- a/include/clhash.h
+++ b/include/clhash.h
@@ -55,4 +55,28 @@ void * get_random_key_for_clhash(uint64_t seed1, uint64_t seed2);
 } // extern "C"
 #endif
 
+#ifdef __cplusplus
+#include <vector>
+
+struct clhasher {
+    const void *random_data_;
+    clhasher(uint64_t seed1=137, uint64_t seed2=777): random_data_(get_random_key_for_clhash(seed1, seed2)) {}
+    template<typename T>
+    uint64_t operator()(const T *data, const size_t len) const {
+        return clhash(random_data_, (const char *)data, len * sizeof(T));
+    }
+    template<typename T>
+    uint64_t operator()(const T &input) const {
+        return operator()((const char *)&input, sizeof(T));
+    }
+    template<typename T>
+    uint64_t operator()(const std::vector<T> &input) const {
+        return operator()((const char *)input.data(), sizeof(T) * input.size());
+    }
+    ~clhasher() {
+        std::free((void *)random_data_);
+    }
+};
+#endif // #ifdef __cplusplus
+
 #endif /* INCLUDE_CLHASH_H_ */

--- a/include/clhash.h
+++ b/include/clhash.h
@@ -58,6 +58,7 @@ void * get_random_key_for_clhash(uint64_t seed1, uint64_t seed2);
 #ifdef __cplusplus
 #include <vector>
 #include <string>
+#include <cstring> // For std::strlen
 
 struct clhasher {
     const void *random_data_;
@@ -66,6 +67,7 @@ struct clhasher {
     uint64_t operator()(const T *data, const size_t len) const {
         return clhash(random_data_, (const char *)data, len * sizeof(T));
     }
+    uint64_t operator()(const char *str) const {return operator()(str, std::strlen(str));}
     template<typename T>
     uint64_t operator()(const T &input) const {
         return operator()((const char *)&input, sizeof(T));

--- a/include/clhash.h
+++ b/include/clhash.h
@@ -57,6 +57,7 @@ void * get_random_key_for_clhash(uint64_t seed1, uint64_t seed2);
 
 #ifdef __cplusplus
 #include <vector>
+#include <string>
 
 struct clhasher {
     const void *random_data_;
@@ -72,6 +73,9 @@ struct clhasher {
     template<typename T>
     uint64_t operator()(const std::vector<T> &input) const {
         return operator()((const char *)input.data(), sizeof(T) * input.size());
+    }
+    uint64_t operator()(const std::string &str) const {
+        return operator()(str.data(), str.size());
     }
     ~clhasher() {
         std::free((void *)random_data_);

--- a/include/clhash.h
+++ b/include/clhash.h
@@ -19,6 +19,10 @@
 #include <stdint.h> // life is short, please use a C99-compliant compiler
 #include <stddef.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 enum {RANDOM_64BITWORDS_NEEDED_FOR_CLHASH=133,RANDOM_BYTES_NEEDED_FOR_CLHASH=133*8};
 
 
@@ -47,5 +51,8 @@ uint64_t clhash(const void* random, const char * stringbyte,
  */
 void * get_random_key_for_clhash(uint64_t seed1, uint64_t seed2);
 
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
 #endif /* INCLUDE_CLHASH_H_ */


### PR DESCRIPTION
I've been using  clhash for over a year in several C++ projects, and it's been great. extern "C" was necessary for linking, and I thought it'd be convenient to have it in the main repository instead of a fork.

I also have an RAII clhasher helper which provides overloads for std::vectors, std::strings and scalars, which is convenient but less necessary.
  